### PR TITLE
Fix Removed Unnecessary Font Names and Semicolon

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,5 +1,5 @@
 :root {
-	--font-fallback: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+	--font-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
 	--font-body: 'IBM Plex Sans', var(--font-fallback);
 	--font-mono: 'IBM Plex Mono', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono',
 		'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
@@ -24,7 +24,7 @@
 	--color-blue-dark: hsl(200, 100%, 30%);
 	--color-blue-dark-hsl: 200, 100%, 30%;
 	--color-green: hsl(158, 78%, 42%);
-	--color-green-dark: hsl(158, 78%, 22%);;
+	--color-green-dark: hsl(158, 78%, 22%);
 	--color-orange: hsl(21, 100%, 60%);
 	--color-orange-dark: hsl(21, 100%, 40%);
 	--color-purple: hsl(269, 79%, 74%);


### PR DESCRIPTION
Last fallback must be sans-serif. In order, after sans-serif, others can't be reachable already. You don't need an emoji font as a fallback, because you are using text. If you insist adding them, consider adding them before 'sans-serif' (last fallback [any sans-serif font]) and surround in single quotes, because they are multi words.